### PR TITLE
Clarify Airbus dataset and experiment provenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,29 @@
 
 This dataset is a demonstration version of larger and more advanced deep learning datasets created from Airbus satellite imagery. It is provided for demonstration purpose only.
 
+> [!IMPORTANT]
+> This is an independent project copy, not an official Airbus repository. Airbus supplied the sample imagery and dataset description, Airbus DS Intelligence curated the dataset, and Appen supplied the annotations. The repository also contains a separate YOLOv5 experiment and generated artifacts described below.
+
+## Repository scope and provenance
+
+The Git history begins with a single import commit and does not preserve a source repository or earlier dataset history. The Airbus sample consists of:
+
+- `images/`: 103 annotated Pléiades image extracts
+- `annotations.csv`: 3,425 aircraft annotations plus the header row
+- `extras/`: 6 unannotated images
+- `LICENSE.txt`: the CC BY-NC-SA 4.0 license text supplied with the data
+
+Repository-specific experiment material includes:
+
+- `aircraft-detection-with-yolov5.ipynb`, which converts the polygon annotations into tiled, single-class YOLO labels and invokes YOLOv5 training and detection
+- `train/` and `val/`, the generated 512 x 512 image tiles and YOLO labels
+- `dataset.yaml`, which contains the original author's absolute local paths and must be reviewed before reuse
+- `wandb/`, saved Weights & Biases run metadata and outputs from December 2021
+- `yolov5s.pt`, a pretrained YOLOv5 checkpoint
+- `yolov5`, a Git link pinned to Ultralytics YOLOv5 commit [`dc54ed5`](https://github.com/ultralytics/yolov5/commit/dc54ed5763720ced4f6784552c47534af5413d45); the repository does not include a `.gitmodules` URL, so a normal clone does not populate it
+
+The notebook records the experiment as run from `/home/bilel/GitHub/Airbus-Aircraft-Detection`, installs from the then-current Ultralytics YOLOv5 repository, requires an interactive Weights & Biases login, and uses machine-specific paths. It is an experiment record, not a portable or currently validated training recipe.
+
 ## Background
 
 [Airbus Defense and Space Intelligence](https://www.intelligence-airbusds.com/) operates the largest commercial satellite constellation combining optical imagery from Pléiades, SPOT, Vision-1 and DMC as well as the radar constellation (consisting of TerraSAR-X, TanDEM-X and PAZ). We are further expanding our sensor capabilities with the upcoming Pléiades Neo constellation providing higher resolution, greater revisits and more acquisition capabilities.
@@ -22,7 +45,7 @@ A folder named `extras` contains 6 extra images which are not annotated but coul
 
 ## License
 
-This data is licensed under the [**Creative Commons BY-NC-SA 4.0 International**](https://creativecommons.org/licenses/by-nc-sa/4.0/) license: 
+The Airbus sample data is licensed under the [**Creative Commons BY-NC-SA 4.0 International**](LICENSE.txt) license:
 
 You are free to :
 - **Share** — copy and redistribute the material in any medium or format
@@ -33,8 +56,10 @@ as long as you follow the following terms:
 - **NonCommercial** — You may not use the material for commercial purposes.
 - **ShareAlike** — If you remix, transform, or build upon the material, you must distribute your contributions under the same license as the original.
 
+The repository also contains third-party YOLOv5 code references and a model checkpoint. Do not assume the dataset license replaces their applicable upstream terms. No ownership of Airbus imagery, Appen annotations, Ultralytics code, or third-party model assets is claimed here.
+
 ## Contact
 
-**We welcome feedback and comments!** This dataset was curated by [jeffaudi](https://twitter.com/jeffaudi) for [Airbus DS Intelligence](https://www.intelligence-airbusds.com/) and annotations provided by [Appen](https://appen.com/). 
+**We welcome feedback and comments!** This dataset was curated by `jeffaudi` for [Airbus DS Intelligence](https://www.intelligence-airbusds.com/) and annotations provided by [Appen](https://appen.com/).
 
-Please contact our [sales team](https://www.intelligence-airbusds.com/contact/) for any question related to our satellite imagery offer or to our **OneAtlas** digital services. 
+Please contact our [sales team](https://www.intelligence-airbusds.com/contact/) for any question related to our satellite imagery offer or to our **OneAtlas** digital services.


### PR DESCRIPTION
## Summary

- distinguish the Airbus sample imagery and annotations from repository-specific YOLOv5 experiment artifacts
- document the actual dataset counts and generated training material
- identify machine-specific notebook/configuration constraints and the incomplete YOLOv5 Git link
- clarify attribution, non-ownership, and dataset-versus-third-party license scope

## Evidence

The tree contains 103 source images, 6 extras, and 3,425 annotation rows. The notebook creates 512-pixel YOLO tiles, uses `/home/bilel/GitHub/Airbus-Aircraft-Detection`, logs into Weights & Biases, and invokes Ultralytics YOLOv5. The `yolov5` Git link is pinned to `dc54ed5763720ced4f6784552c47534af5413d45`, but no `.gitmodules` file supplies its URL.

## Validation

- `git diff --check`
- verified all referenced paths and the pinned YOLOv5 commit from the Git tree
- verified the repository `LICENSE.txt` URL and Ultralytics commit URL
- external link check passes except for the relative `LICENSE.txt` false positive caused by the local README-only sparse checkout